### PR TITLE
Batch redraws for mithril timers bench

### DIFF
--- a/client/apps/mithril/timers-test/index.js
+++ b/client/apps/mithril/timers-test/index.js
@@ -16,6 +16,8 @@ module.exports = {
       })
     }
 
+    setInterval(() => m.redraw(), 10)
+
     ctrl.captureUpdateStats = () => timerStats.capture()
     timerStats.init(10)
 

--- a/client/apps/mithril/timers-test/timer-item.js
+++ b/client/apps/mithril/timers-test/timer-item.js
@@ -7,12 +7,9 @@ module.exports = {
 
     args.item.intervalID = setInterval(() => {
       args.item.value = Math.random() * 100
-      m.redraw()
     }, Math.random() * 10)
 
-    ctrl.config = (el, init, ctx) => {
-      args.capture()
-    }
+    ctrl.config = () => args.capture()
 
     return ctrl
   },


### PR DESCRIPTION
### [Mithril timers bench is now almost twice as fast then Oval :stuck_out_tongue_closed_eyes: ](https://www.youtube.com/watch?v=BfgnTMIphfo)

According to Mithril's [documentation](http://mithril.js.org/mithril.redraw.html):

> `m.redraw` is "aggressive": it redraws as many times as it is called (with the caveat that redraws are batched if they occur less than one animation frame apart in time)

Unfortunately that doesn't seems to happen when `m.redraw` is called multiple times inside each and every timeout. So instead I'm batching the redraws manually. 

Mithril doesn't have the concept of redrawing a single component, instead it have only one redraw cycle, and that is the **global** one. So from Mithril's point of view this fix isn't even a hack, but you can try similar approach with Oval and see how it compares.
