### PR TITLE
Migrate to Mithril 1.0

### DIFF
--- a/client/apps/mithril/each-loop-test/index.js
+++ b/client/apps/mithril/each-loop-test/index.js
@@ -3,10 +3,10 @@ var m = window.mithril
 var Item = require('./item')
 
 module.exports = {
-  controller: function () {
+  oninit: function (vnode) {
     console.time('each-loop-mount')
+    var ctrl = this
 
-    var ctrl = {}
     ctrl.items = []
     for (var i = 0; i < 10000; i++) {
       ctrl.items.push({value: i, id: Math.random()})
@@ -16,26 +16,24 @@ module.exports = {
       ctrl.items.push({value: ctrl.items.length, id: Math.random()})
     }
     ctrl.refresh = () => {
-      m.startComputation()
-      m.endComputation()
+      m.redraw()
     }
     ctrl.removeItem = (item) => () => {
       ctrl.items.splice(ctrl.items.indexOf(item), 1)
     }
 
-    ctrl.config = (el, init, ctx) => {
-      if (!init) {
-        console.timeEnd('each-loop-mount')
-      }
+    ctrl.oncreate = (vnode) => {
+      console.timeEnd('each-loop-mount')
+    }
+    ctrl.onupdate = (vnode) => {
       console.timeEnd('each-loop')
     }
-
-    return ctrl
   },
-  view: (ctrl) => {
+  view: (vnode) => {
     console.time('each-loop')
+    var ctrl = vnode.state
     return (
-      m('div', {config: ctrl.config}, [
+      m('div', {oncreate: ctrl.oncreate, onupdate: ctrl.onupdate}, [
         m('h1', 'Each Loop test'),
         m('button', {onclick: ctrl.addItem}, 'add item'),
         m('button', {onclick: ctrl.refresh}, 'refresh'),

--- a/client/apps/mithril/each-loop-test/item.js
+++ b/client/apps/mithril/each-loop-test/item.js
@@ -2,14 +2,13 @@
 var m = window.mithril
 
 module.exports = {
-  controller: function () {
-    return {
-      rendered: false,
-      items: [1, 2, 3]
-    }
+  oninit: function (vnode) {
+    vnode.state.items = [1, 2, 3]
   },
-  view: (ctrl, args) =>
-    (!ctrl.rendered)
-      ? m('span', [args.value, ' ', ctrl.items.map((item) => m('span', item))])
-      : {subtree: 'retain'}
+  view: (vnode) =>
+    m('span', [
+      vnode.attrs.value,
+      ' ',
+      vnode.state.items.map((item) => m('span', item))
+    ])
 }

--- a/client/apps/mithril/timers-test/index.js
+++ b/client/apps/mithril/timers-test/index.js
@@ -3,9 +3,9 @@ var m = window.mithril
 var Item = require('./timer-item')
 
 module.exports = {
-  controller: function () {
+  oninit: function (vnode) {
     var timerStats = require('timers-stats')
-    var ctrl = {}
+    var ctrl = this
 
     ctrl.items = []
     for (var i = 0; i < 2000; i++) {
@@ -18,11 +18,9 @@ module.exports = {
 
     ctrl.captureUpdateStats = () => timerStats.capture()
     timerStats.init(10)
-
-    return ctrl
   },
-  view: (ctrl) =>
-    ctrl.items.map((item) =>
-      m(Item, {item, capture: ctrl.captureUpdateStats})
+  view: (vnode) =>
+    vnode.state.items.map((item) =>
+      m(Item, {item, capture: vnode.state.captureUpdateStats})
     )
 }

--- a/client/apps/mithril/timers-test/timer-item.js
+++ b/client/apps/mithril/timers-test/timer-item.js
@@ -2,20 +2,22 @@
 var m = window.mithril
 
 module.exports = {
-  controller: function (args) {
-    var ctrl = {}
+  oninit: function (vnode) {
+    var ctrl = this
+    var args = vnode.attrs
 
     args.item.intervalID = setInterval(() => {
       args.item.value = Math.random() * 100
       m.redraw()
     }, Math.random() * 10)
 
-    ctrl.config = (el, init, ctx) => {
-      args.capture()
-    }
+    ctrl.onupdate = () => args.capture()
 
     return ctrl
   },
-  view: (ctrl, args) =>
-    m('div', {config: ctrl.config}, args.item.id + ' - ', args.item.value)
+  view: (vnode) =>
+    m('div',
+      {onupdate: vnode.state.onupdate},
+      vnode.attrs.item.id + ' - ', vnode.attrs.item.value
+    )
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "loader-utils": "^0.2.15",
     "lodash": "^4.4.0",
     "method-override": "^2.3.1",
-    "mithril": "^0.2.5",
+    "mithril": "lhorie/mithril.js#rewrite",
     "organic-angel": "^0.3.2",
     "organic-bunyan-output": "0.0.4",
     "organic-console": "0.0.2",


### PR DESCRIPTION
I decided to drop the benchmarks for Mithril 0.x entirely and migrate to Mithril 1.0 instead. Last time I checked the rewrite was deemed unstable, but now it seems to be pretty stable, although not officially published yet.

Another thing is that Mithril 0.x is in maintenance mode for a very long time now and performance improvements are not being added there.

The rewrite is hosted [here](https://github.com/lhorie/mithril.js/tree/rewrite). The updated docs are [here](https://github.com/lhorie/mithril.js/tree/rewrite/docs), and more importantly the [migration guide](https://github.com/lhorie/mithril.js/blob/rewrite/docs/v1.x-migration.md).

The initial loading of the _for-each_ benchmark is faster than Oval. Removing, adding and refreshing the items is pretty much the same as in Oval, so good job on that.

The timers demo calls `m.redraw` inside each and every interval timeout, so at least from the end-user's point of view the code looks identical to any other framework. No more batch redraw called outside of the async callbacks. Seems to be working this time.
